### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/zendesk/ZendeskConnection.java
+++ b/src/main/java/io/kestra/plugin/zendesk/ZendeskConnection.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -39,24 +40,28 @@ public abstract class ZendeskConnection extends Task {
         description = "Base domain of the Zendesk instance; `https://` is added if missing and trailing slash is removed."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> domain;
 
     @Schema(
         title = "Zendesk username",
         description = "Account email used with an API token for basic authentication."
     )
+    @PluginProperty(group = "connection")
     private Property<String> username;
 
     @Schema(
         title = "Zendesk API token",
         description = "API token for basic auth; pair it with `username`."
     )
+    @PluginProperty(group = "connection")
     private Property<String> token;
 
     @Schema(
         title = "Zendesk OAuth token",
         description = "Bearer token alternative to username/token; send as Authorization: Bearer."
     )
+    @PluginProperty(group = "connection")
     private Property<String> oauthToken;
 
     public <T> T makeCall(RunContext runContext, String body, Class<T> clazz) throws Exception {

--- a/src/main/java/io/kestra/plugin/zendesk/tickets/Create.java
+++ b/src/main/java/io/kestra/plugin/zendesk/tickets/Create.java
@@ -146,37 +146,42 @@ public class Create extends ZendeskConnection implements RunnableTask<Create.Out
         title = "Ticket subject line",
         description = "Short summary shown in Zendesk; rendered from the RunContext."
     )
+    @PluginProperty(group = "main")
     private Property<String> subject;
 
     @Schema(
         title = "Ticket description",
         description = "Body of the ticket; templated via RunContext and supports multiline text."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     private String description;
 
     @Schema(
         title = "Priority",
         description = "Optional Zendesk priority. Allowed values: URGENT, HIGH, NORMAL, LOW. Leave blank to use Zendesk's default."
     )
+    @PluginProperty(group = "advanced")
     private Property<Priority> priority;
 
     @Schema(
         title = "Ticket type",
         description = "Optional Zendesk type. Allowed values: PROBLEM, INCIDENT, QUESTION, TASK."
     )
+    @PluginProperty(group = "advanced")
     private Property<Type> ticketType;
 
     @Schema(
         title = "Assignee ID",
         description = "Numeric Zendesk assignee ID; omit to leave unassigned."
     )
+    @PluginProperty(group = "advanced")
     private Property<Long> assigneeId;
 
     @Schema(
         title = "Ticket tags",
         description = "List of tags to apply to the ticket; rendered from the RunContext."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> tags;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712